### PR TITLE
Convert all `training_time` fields to use petaflop/s-day

### DIFF
--- a/assets/deepmind.yaml
+++ b/assets/deepmind.yaml
@@ -125,11 +125,8 @@
     explanation: >
       The authors reported the training petaflops for all of the 4 different
       sizes of the model. For the 280B parameter model, the petaflops was
-      reported as 6.31E+08. A petaflop/s-day corresponds to a petaflop
-      operations per second per day
-      [[OpenAI AI and Computer Blog]](https://openai.com/blog/ai-and-compute/#addendum).
-      Hence, we can compute the Gopher's training time in petaflop/s-day as
-      6.31E+08 / (60*60*24) = 7303.24 petaflop/s-day.
+      reported as 6.31E+08. We compute the Gopher's training time in
+      petaflop/s-day as 6.31E+08 / (60*60*24) = 7303.24 petaflop/s-day.
   training_hardware:
     value: TPUv3 pods
     explanation: >

--- a/assets/eleutherai.yaml
+++ b/assets/eleutherai.yaml
@@ -121,23 +121,16 @@
   training_time:
     value: 47.10 petaflop/s-day
     explanation: >
-      Training time was reported as 1830 hours reported by the authors
+      Training time was reported as 1830 hours reported by the authors, equaling
+      76.25 days.
       [[Section 6.4]](http://eaidata.bmk.sh/data/GPT_NeoX_20B.pdf#subsection.6.4).
-      Using the GPU Time method outlined in the
+      The authors report that 96 (12 * 8) A100 GPUs were used during the
+      training.
+      The A100 GPUs have a single precision performance of 0.0195 petaflops
+      [[A100 Datasheet]](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-us-nvidia-1758950-r4-web.pdf).
+      Assuming the estimated utilization is 33%, following
       [[OpenAI AI and Computer Blog]](https://openai.com/blog/ai-and-compute/#addendum),
-      we can compute the training time in petaflop/s-day using the following
-      equation: Number of GPUs * (peta-flops/GPU) * days trained *
-      estimated utilization. The authors of the paper reports that 12 * 8 = 96
-      A100 GPUs were used to train GPT-NeoX-20B. The A100 GPUs have a single
-      precision performance of 19.5 teraflops
-      [[A100 Datasheet]](https://www.nvidia.com/content/dam/en-zz/Solutions/Data-Center/a100/pdf/nvidia-a100-datasheet-us-nvidia-1758950-r4-web.pdf),
-      which is equal to 19.5 / 1000 = 0.0195 petaflops. We can compute the
-      number of days trained as 1830 / 24 = 76.25. Finally, we assume that the
-      estimated utilization is 33%, following
-      [[OpenAI AI and Computer Blog]](https://openai.com/blog/ai-and-compute/#addendum).
-      This leaves us with: "Number of GPUs" = 96, "peta-flops/GPU" = 0.0195,
-      "days trained" = 76.25, and "estimated utilization" = 0.33. Multiplying
-      all together gives us 96 * 0.0195 * 76.25 * 0.33 = 47.10 petaflop/s-day.
+      the training time is 47.10 petaflop/s-day (76.25 * 96 * 0.0195 * 0.33).
   training_hardware:
     value: 12 x 8 A100 GPUs
     explanation: >

--- a/assets/openai.yaml
+++ b/assets/openai.yaml
@@ -382,8 +382,7 @@
       The time required to train different sized GPT-3 models are listed in
       [[Table D.1]](https://arxiv.org/pdf/2005.14165.pdf#table.caption.50).
       The time required to train the GPT-3 model with 175B parameters is
-      reported as 3.64E+03 petaflop days, which is the same as 3640 petaflop
-      days.
+      reported as 3.64E+03 petaflop/s-days.
   training_hardware:
     value: Azure
     explanation: >
@@ -480,7 +479,7 @@
     value: Unknown
     explanation: Authors do not report the training emissions.
   training_time:
-    value: Unknown
+    value: 100-1000 petaflop/s-days
     explanation: >
       Authors estimate hundreds of petaflop/s-days of compute
       [[Section 7.6]](https://arxiv.org/pdf/2107.03374.pdf#subsection.7.6), but


### PR DESCRIPTION
## Purpose

This PR standardizes the `training_time` field to always use `petaflop/s-day`. Simply reporting the number of `hours` or `days` trained makes it hard to compare different models due to the use of different hardware. We use the methods outlined in [[OpenAI AI and Compute]](https://openai.com/blog/ai-and-compute/#addendum) post to convert the training time reported in number of `hours`, `days` or `petaflops` to `petaflop/s-day`. The `petaflop/s-day` metric is also a useful metric as it is commonly used to report training time in the newly released models.

## Comments

Although it provides a standard look at the training times of different models, the `petaflop/s-day` may not be meaningful to the general public. I propose using it as the standard metric in our assets, but converting it into different metrics on the UI, depending on our needs (we can convert `petaflop/s-day` back into hours or days by saying that we assume that all the models used a certain GPU). 